### PR TITLE
Removed Privileged access mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Note: in order to prevent docker from turning Cumulus.ini into a folder, you need to touch it first
 # eg. touch /opt/MXWeather/Cumulus.ini
 # To build:  docker build -t ubuntu:MXWeather .
-# To run:    docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --privileged --device=/dev:/dev -d ubuntu:MXWeather
+# To run:    docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --device=/dev/hidraw0 -d ubuntu:MXWeather
 # Weather data, logs, and settings are persistent outside of the container
 
 # Pull base image.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Run the following commands to prepare and start the container:
 * cd /opt/MXWeather
 * touch Cumulus.ini
 * docker build -t ubuntu:MXWeather .
-* docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --privileged --device=/dev:/dev -d ubuntu:MXWeather
+* docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --device=/dev/hidraw0 -d ubuntu:MXWeather
 
 Known Issues:
-* Requires Privileged Level Access: 
-The --privileged switch is required for the --device=/dev:/dev mapping to work correctly. Unfortunately while CumulusMX can see the USB devices in the container, it doesn't seem to be able to open the stream with out privileged access. Originally it was tried using /dev/usb:/dev/usb as the device mapping howevever although CumulusMX reported that it could both see the device, and open the stream, it never read any data back. 
 
+TODO:
+* Haven't developed a Docker-create.yml as yet. 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 This repo is the files required to build CumulusMX into a Docker container.
 
+## Usage
 Clone the repo into a folder (I generally use /opt/MXWeather/) on the Docker host.
 Run the following commands to prepare and start the container:
-* cd /opt/MXWeather
-* touch Cumulus.ini
-* docker build -t ubuntu:MXWeather .
-* docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --device=/dev/hidraw0 -d ubuntu:MXWeather
+* `cd /opt/MXWeather`
+* `touch Cumulus.ini`
+* `docker build -t ubuntu:MXWeather .`
+* `docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --device=/dev/hidraw0 -d ubuntu:MXWeather`
 
-Known Issues:
+## Known Issues:
+* None
 
-TODO:
-* Haven't developed a Docker-create.yml as yet. 
+## TODO:
+* Need to build a Docker-create.yml. 

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd /opt/MXWeather
+docker stop MXWeather && docker rm MXWeather
+docker build -t ubuntu:MXWeather .
+docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --privileged -d ubuntu:MXWeather

--- a/update.sh
+++ b/update.sh
@@ -2,4 +2,4 @@
 cd /opt/MXWeather
 docker stop MXWeather && docker rm MXWeather
 docker build -t ubuntu:MXWeather .
-docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --privileged -d ubuntu:MXWeather
+docker run --name=MXWeather -p 8998:8998 -p 8080:80 -v /opt/MXWeather/data:/opt/CumulusMX/data -v /opt/MXWeather/backup:/opt/CumulusMX/backup -v /opt/MXWeather/log:/var/log/nginx -v /opt/MXWeather/Cumulus.ini:/opt/CumulusMX/Cumulus.ini --device=/dev/hidraw0 -d ubuntu:MXWeather


### PR DESCRIPTION
Determined that the USB device actually mapped two devices to /dev (/dev/usb/hiddev0, and /dev/hidraw0) mapping the hidraw0 device instead of the hiddev0 device allowed the device to work correctly. Updated the configuration information.